### PR TITLE
Timing fix

### DIFF
--- a/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
@@ -89,7 +89,7 @@ public class ExecutionUnitRunner extends ParentRunner<Step> {
         jUnitReporter.startExecutionUnit(this, notifier);
         // This causes runChild to never be called, which seems OK.
         cucumberScenario.run(jUnitReporter, jUnitReporter, runtime);
-        jUnitReporter.finishExecutionUnit();
+        jUnitReporter.skipExecutionUnitIfIgnored();
     }
 
     @Override

--- a/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
+++ b/junit/src/main/java/cucumber/runtime/junit/ExecutionUnitRunner.java
@@ -89,7 +89,7 @@ public class ExecutionUnitRunner extends ParentRunner<Step> {
         jUnitReporter.startExecutionUnit(this, notifier);
         // This causes runChild to never be called, which seems OK.
         cucumberScenario.run(jUnitReporter, jUnitReporter, runtime);
-        jUnitReporter.skipExecutionUnitIfIgnored();
+        jUnitReporter.finishExecutionUnit();
     }
 
     @Override

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -50,10 +50,11 @@ public class JUnitReporter implements Reporter, Formatter {
         executionUnitNotifier.fireTestStarted();
     }
 
-    public void skipExecutionUnitIfIgnored() {
+    public void finishExecutionUnit() {
         if (ignoredStep) {
             executionUnitNotifier.fireTestIgnored();
         }
+        executionUnitNotifier.fireTestFinished();
     }
 
     public void match(Match match) {

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -50,11 +50,10 @@ public class JUnitReporter implements Reporter, Formatter {
         executionUnitNotifier.fireTestStarted();
     }
 
-    public void finishExecutionUnit() {
+    public void skipExecutionUnitIfIgnored() {
         if (ignoredStep) {
             executionUnitNotifier.fireTestIgnored();
         }
-        executionUnitNotifier.fireTestFinished();
     }
 
     public void match(Match match) {

--- a/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
+++ b/junit/src/main/java/cucumber/runtime/junit/JUnitReporter.java
@@ -61,6 +61,7 @@ public class JUnitReporter implements Reporter, Formatter {
         Step runnerStep = fetchAndCheckRunnerStep();
         Description description = executionUnitRunner.describeChild(runnerStep);
         stepNotifier = new EachTestNotifier(runNotifier, description);
+        stepNotifier.fireTestStarted();
         reporter.match(match);
     }
 
@@ -91,8 +92,6 @@ public class JUnitReporter implements Reporter, Formatter {
             addFailureOrIgnoreStep(result);
         } else {
             if (stepNotifier != null) {
-                //Should only fireTestStarted if not ignored
-                stepNotifier.fireTestStarted();
                 if (error != null) {
                     stepNotifier.addFailure(error);
                 }

--- a/junit/src/main/java/cucumber/runtime/junit/SanityChecker.java
+++ b/junit/src/main/java/cucumber/runtime/junit/SanityChecker.java
@@ -1,39 +1,33 @@
 package cucumber.runtime.junit;
 
-import junit.framework.AssertionFailedError;
-import junit.framework.JUnit4TestAdapter;
-import junit.framework.Test;
-import junit.framework.TestListener;
-import junit.framework.TestResult;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.notification.RunListener;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.List;
-import junit.framework.JUnit4TestCaseFacade;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
 
 /**
  * Listener that makes sure Cucumber fires events in the right order
  */
-public class SanityChecker implements TestListener {
+public class SanityChecker extends RunListener {
     private static final String INDENT = "  ";
     public static final String INSANITY = "INSANITY";
 
-    private List<Test> tests = new ArrayList<Test>();
+    private List<Description> testDescriptions = new ArrayList<Description>();
     private final StringWriter out = new StringWriter();
 
     public static void run(Class<?> testClass) {
+        run(testClass, false);
     }
 
     public static void run(Class<?> testClass, boolean debug) {
-        JUnit4TestAdapter testAdapter = new JUnit4TestAdapter(testClass);
-        TestResult result = new TestResult();
+        JUnitCore runner = new JUnitCore();
         SanityChecker listener = new SanityChecker();
-        result.addListener(listener);
-        testAdapter.run(result);
+        runner.addListener(listener);
+        runner.run(testClass);
         String output = listener.getOutput();
         if (output.contains(INSANITY)) {
             throw new RuntimeException("Something went wrong\n" + output);
@@ -46,37 +40,18 @@ public class SanityChecker implements TestListener {
     }
 
     @Override
-    public void addError(Test test, Throwable t) {
-    }
-
-    @Override
-    public void addFailure(Test test, AssertionFailedError t) {
-    }
-
-    @Override
-    public void startTest(Test started) {
+    public void testStarted(Description started) {
         spaces();
-        out.append("START " + started.toString()).append("\n");
-        tests.add(started);
+        out.append("START  " + started.toString()).append("\n");
+        testDescriptions.add(started);
     }
 
     @Override
-    public void endTest(Test ended) {
+    public void testFinished(Description ended) {
         try {
-            Test lastStarted = tests.remove(tests.size() - 1);
+            Description lastStarted = testDescriptions.remove(testDescriptions.size() - 1);
             spaces();
-            out.append("END   " + ended.toString()).append("\n");
-            //Handle skipped tests
-            if (!(lastStarted instanceof TestSuite) && ended instanceof TestSuite) {
-                Enumeration<Test> endedTests = ((TestSuite) ended).tests();
-                while (endedTests.hasMoreElements()) {
-                    Test test = endedTests.nextElement();
-                    //If test in stest suite - all ok
-                    if (test.equals(lastStarted)) {
-                        return;
-                    }
-                }
-            }            
+            out.append("END    " + ended.toString()).append("\n");
             if (!lastStarted.toString().equals(ended.toString())) {
                 out.append(INSANITY).append("\n");
                 String errorMessage = String.format("Started : %s\nEnded   : %s\n", lastStarted, ended);
@@ -88,8 +63,29 @@ public class SanityChecker implements TestListener {
         }
     }
 
+    @Override
+    public void testIgnored(Description ignored) {
+        try {
+            Description lastStarted = testDescriptions.remove(testDescriptions.size() - 1);
+            spaces();
+            out.append("IGNORE " + ignored.toString()).append("\n");
+            // For suites both a testIgnored and a testFinished is sent
+            if (ignored.isSuite()) {
+                testDescriptions.add(lastStarted);
+            }
+            if (!lastStarted.toString().equals(ignored.toString())) {
+                out.append(INSANITY).append("\n");
+                String errorMessage = String.format("Started : %s\nIgnored : %s\n", lastStarted, ignored);
+                out.append(errorMessage).append("\n");
+            }
+        } catch (Exception e) {
+            out.append(INSANITY).append("\n");
+            e.printStackTrace(new PrintWriter(out));
+        }
+    }
+
     private void spaces() {
-        for (int i = 0; i < tests.size(); i++) {
+        for (int i = 0; i < testDescriptions.size(); i++) {
             out.append(INDENT);
         }
     }

--- a/junit/src/main/java/cucumber/runtime/junit/SanityChecker.java
+++ b/junit/src/main/java/cucumber/runtime/junit/SanityChecker.java
@@ -9,7 +9,11 @@ import junit.framework.TestResult;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
+import junit.framework.JUnit4TestCaseFacade;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 
 /**
  * Listener that makes sure Cucumber fires events in the right order
@@ -62,6 +66,17 @@ public class SanityChecker implements TestListener {
             Test lastStarted = tests.remove(tests.size() - 1);
             spaces();
             out.append("END   " + ended.toString()).append("\n");
+            //Handle skipped tests
+            if (!(lastStarted instanceof TestSuite) && ended instanceof TestSuite) {
+                Enumeration<Test> endedTests = ((TestSuite) ended).tests();
+                while (endedTests.hasMoreElements()) {
+                    Test test = endedTests.nextElement();
+                    //If test in stest suite - all ok
+                    if (test.equals(lastStarted)) {
+                        return;
+                    }
+                }
+            }            
             if (!lastStarted.toString().equals(ended.toString())) {
                 out.append(INSANITY).append("\n");
                 String errorMessage = String.format("Started : %s\nEnded   : %s\n", lastStarted, ended);

--- a/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
@@ -264,6 +264,23 @@ public class JUnitReporterTest {
         }
     }
 
+    @Test
+    public void match_fires_test_started_for_the_step() {
+        Step runnerStep = mockStep("Step Name");
+        Description runnerStepDescription = stepDescription(runnerStep);
+        ExecutionUnitRunner executionUnitRunner = mockExecutionUnitRunner(runnerSteps(runnerStep));
+        when(executionUnitRunner.describeChild(runnerStep)).thenReturn(runnerStepDescription);
+        createNonStrictReporter();
+        runNotifier = mock(RunNotifier.class);
+
+        jUnitReporter.startExecutionUnit(executionUnitRunner, runNotifier);
+        jUnitReporter.startOfScenarioLifeCycle(mock(Scenario.class));
+        jUnitReporter.step(runnerStep);
+        jUnitReporter.match(mock(Match.class));
+
+        verify(runNotifier).fireTestStarted(runnerStepDescription);
+    }
+
     private Result mockResult() {
         Result result = mock(Result.class);
         when(result.getStatus()).thenReturn("passed");

--- a/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
+++ b/junit/src/test/java/cucumber/runtime/junit/JUnitReporterTest.java
@@ -64,7 +64,6 @@ public class JUnitReporterTest {
 
         jUnitReporter.result(Result.UNDEFINED);
 
-        verify(stepNotifier, times(0)).fireTestStarted();
         verify(stepNotifier, times(0)).fireTestFinished();
         verify(stepNotifier, times(0)).addFailure(Matchers.<Throwable>any(Throwable.class));
         verify(stepNotifier).fireTestIgnored();
@@ -81,7 +80,6 @@ public class JUnitReporterTest {
 
         jUnitReporter.result(Result.UNDEFINED);
 
-        verify(stepNotifier, times(1)).fireTestStarted();
         verify(stepNotifier, times(1)).fireTestFinished();
         verifyAddFailureWithPendingException(stepNotifier);
         verifyAddFailureWithPendingException(executionUnitNotifier);
@@ -106,7 +104,6 @@ public class JUnitReporterTest {
 
         jUnitReporter.result(result);
 
-        verify(stepNotifier, times(0)).fireTestStarted();
         verify(stepNotifier, times(0)).fireTestFinished();
         verify(stepNotifier, times(0)).addFailure(Matchers.<Throwable>any(Throwable.class));
         verify(stepNotifier).fireTestIgnored();
@@ -126,7 +123,6 @@ public class JUnitReporterTest {
 
         jUnitReporter.result(result);
 
-        verify(stepNotifier, times(1)).fireTestStarted();
         verify(stepNotifier, times(1)).fireTestFinished();
         verifyAddFailureWithPendingException(stepNotifier);
         verifyAddFailureWithPendingException(executionUnitNotifier);
@@ -143,7 +139,6 @@ public class JUnitReporterTest {
 
         jUnitReporter.result(result);
 
-        verify(stepNotifier).fireTestStarted();
         verify(stepNotifier).fireTestFinished();
         verify(stepNotifier, times(0)).addFailure(Matchers.<Throwable>any(Throwable.class));
         verify(stepNotifier, times(0)).fireTestIgnored();
@@ -159,7 +154,6 @@ public class JUnitReporterTest {
 
         jUnitReporter.result(result);
 
-        verify(stepNotifier).fireTestStarted();
         verify(stepNotifier).fireTestFinished();
         verify(stepNotifier, times(0)).addFailure(Matchers.<Throwable>any(Throwable.class));
         verify(stepNotifier, times(0)).fireTestIgnored();


### PR DESCRIPTION
This is bug fix for test steps execution time. It was fired fireTestStarted event after test was performed. 
I was moved event at the start of step execution. Now timings calculated right.

In tests I was just removed fireTestStarted execution verification because it not performed in that places.
